### PR TITLE
Remove `set-output` usage in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,11 +40,11 @@ runs:
         app_id = "${{ inputs.app-id }}"
         pem = b"""${{ inputs.private-key }}"""
         if not app_id or not pem:
-          print("Missing app-id or pem")
-          github_output = os.environ["GITHUB_OUTPUT"]
-          with open(github_output, "a") as f:
-              f.write(f"token=none\n")
-          exit(1)
+            print("Missing app-id or pem")
+            github_output = os.environ["GITHUB_OUTPUT"]
+            with open(github_output, "a") as f:
+                f.write(f"token=none\n")
+            exit(1)
         signing_key = jwt.jwk_from_pem(pem)
         payload = {
             # Issued at time

--- a/action.yml
+++ b/action.yml
@@ -40,8 +40,11 @@ runs:
         app_id = "${{ inputs.app-id }}"
         pem = b"""${{ inputs.private-key }}"""
         if not app_id or not pem:
-            print(f"::set-output name=token::none")
-            exit()
+          print("Missing app-id or pem")
+          github_output = os.environ["GITHUB_OUTPUT"]
+          with open(github_output, "a") as f:
+              f.write(f"token=none\n")
+          exit()
         signing_key = jwt.jwk_from_pem(pem)
         payload = {
             # Issued at time

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
           github_output = os.environ["GITHUB_OUTPUT"]
           with open(github_output, "a") as f:
               f.write(f"token=none\n")
-          exit()
+          exit(1)
         signing_key = jwt.jwk_from_pem(pem)
         payload = {
             # Issued at time


### PR DESCRIPTION
As `set-output` usage in Github Actions may be removed soon (postponed from 2023-07-24), use writing to GITHUB_OUTPUT there as well.
It may introduce an error source if the GITHUB_OUTPUT file is unwritable (for unknown reasons). Also print a message to stdout if an input is missing.

Maybe exit with an error as well when this happens?