### PR TITLE
ci: Fix third-party python deps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,10 @@ runs:
       shell: bash
       run: |
         echo "-- Install Python JWT package"
-        pip install --user jwt || exit 1
+        pip install --user cffi==1.16.0 || exit 1
+        pip install --user cryptography==42.0.5 || exit 1
+        pip install --user jwt==1.3.1 || exit 1
+        pip install --user pycparser==2.21 || exit 1
     - name: "Generate App JWT"
       # Generate a JWT token signed by the GitHub App, that can be used to call the GitHub API
       shell: python


### PR DESCRIPTION
Maybe it would be good to fix security related python dependencies as we don't, by default, trust third-party software.

This fixes jwt and also all of it's dependencies.

It hasn't been touched since 2021 so it may not be so critical. Probably good practice.

Also, since it hasn't been touched since 2021 I guess we should not have to worry about bumping versions too much.