### PR TITLE
refactor: try to make action usable with non-default runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: action/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
       with:
         python-version: 3.12
     - name: "Install Python JWT package"

--- a/action.yml
+++ b/action.yml
@@ -20,15 +20,18 @@ outputs:
 runs:
   using: composite
   steps:
+    - uses: action/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+      with:
+        python-version: 3.12
     - name: "Install Python JWT package"
       # Install Python JWT package
       shell: bash
       run: |
         echo "-- Install Python JWT package"
-        pip install --user cffi==1.16.0 || exit 1
-        pip install --user cryptography==42.0.5 || exit 1
-        pip install --user jwt==1.3.1 || exit 1
-        pip install --user pycparser==2.21 || exit 1
+        pip install cffi==1.16.0 || exit 1
+        pip install cryptography==42.0.5 || exit 1
+        pip install jwt==1.3.1 || exit 1
+        pip install pycparser==2.21 || exit 1
     - name: "Generate App JWT"
       # Generate a JWT token signed by the GitHub App, that can be used to call the GitHub API
       shell: python


### PR DESCRIPTION
This may not be needed anymore, we currently extend our runner image with a python installation with user-package-overrides.

**BUUUT** this is helpful in container jobs without python/no user-package-overrides, so it works as expected. See recent flash-tool PR.

~Trying to ensure python and pip are available via the setup-python action. Curl should hopefully be in Github's action-runner image...~